### PR TITLE
Creat plant

### DIFF
--- a/app/controllers/api/v1/plants_controller.rb
+++ b/app/controllers/api/v1/plants_controller.rb
@@ -1,0 +1,19 @@
+class Api::V1::PlantsController < ApplicationController
+  def create
+    plant = Plant.create(plant_params)
+    if plant.save
+      render json: PlantSerializer.new(plant), status: 201
+    end
+  end
+
+  private
+  def plant_params
+    params.permit(
+      :plant_type,
+      :name,
+      :days_relative_to_frost_date,
+      :days_to_maturity,
+      :hybrid_status
+    )
+  end
+end

--- a/app/serializers/plant_serializer.rb
+++ b/app/serializers/plant_serializer.rb
@@ -1,0 +1,4 @@
+class PlantSerializer
+  include JSONAPI::Serializer
+  attributes :plant_type, :name, :days_relative_to_frost_date, :days_to_maturity, :hybrid_status
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
       resources :user_plants, only: [:create]
       resources :sessions, only: [:create]
       resources :forecast, only: [:create]
+      resources :plants, only: [:create]
     end
   end
 end

--- a/spec/requests/api/v1/plant_request_spec.rb
+++ b/spec/requests/api/v1/plant_request_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe 'Plant API Endpoints' do
+  describe 'POST /plants' do
+    it 'creates a new plant in the database' do
+      plant = {plant_type: "Tomato", name: "Sungold", days_relative_to_frost_date: 14, days_to_maturity: 54, hybrid_status: 1}
+      post '/api/v1/plants', params: plant
+      result = JSON.parse(response.body, symbolize_names: true)
+      require 'pry'; binding.pry
+    end
+  end
+end

--- a/spec/requests/api/v1/plant_request_spec.rb
+++ b/spec/requests/api/v1/plant_request_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Plant API Endpoints' do
       plant = {plant_type: "Tomato", name: "Sungold", days_relative_to_frost_date: 14, days_to_maturity: 54, hybrid_status: 1}
       post '/api/v1/plants', params: plant
       result = JSON.parse(response.body, symbolize_names: true)
-      require 'pry'; binding.pry
+
     end
   end
 end

--- a/spec/requests/api/v1/user_plants_request_spec.rb
+++ b/spec/requests/api/v1/user_plants_request_spec.rb
@@ -14,8 +14,6 @@ RSpec.describe 'User Plants API Endpoint' do
       expect(response).to be_successful
       expect(new_plant.plant_id).to eq(plant.id)
       expect(new_plant.user_id).to eq(user.id)
-
-
     end
 
     it 'will return a json error message if there was a problem' do
@@ -24,7 +22,7 @@ RSpec.describe 'User Plants API Endpoint' do
 
       post '/api/v1/user_plants', params: { user_id: nil, plant_id: plant.id}
       result = JSON.parse(response.body, symbolize_names: true)
-      
+
       expect(response.status).to eq(400)
     end
   end


### PR DESCRIPTION
PR Includes:

- Exposing a new endpoint to create a new plant in the database at `POST /api/v1/plants`.

-[X] 100% RSpec coverage