### PR TITLE
Remove user plant endpoint

### DIFF
--- a/app/controllers/api/v1/user_plants_controller.rb
+++ b/app/controllers/api/v1/user_plants_controller.rb
@@ -9,4 +9,12 @@ class Api::V1::UserPlantsController < ApplicationController
       render json: UserPlantSerializer.error("There was a problem."), status: 400
     end
   end
+
+  def destroy
+    user_plant = UserPlant.find(params[:id])
+    if user_plant != nil
+      result = UserPlant.destroy(user_plant.id)
+      render json: UserPlantSerializer.new(result), status: 200
+    end
+  end
 end

--- a/app/serializers/user_plant_serializer.rb
+++ b/app/serializers/user_plant_serializer.rb
@@ -1,6 +1,6 @@
 class UserPlantSerializer
   include JSONAPI::Serializer
-
+  attributes :id, :user_id, :plant_id
 
   def self.format(user, plant)
     {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :users, only: [:create]
-      resources :user_plants, only: [:create]
+      resources :user_plants, only: [:create, :destroy]
       resources :sessions, only: [:create]
       resources :forecast, only: [:create]
       resources :plants, only: [:create]

--- a/spec/requests/api/v1/user_plants_request_spec.rb
+++ b/spec/requests/api/v1/user_plants_request_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe 'User Plants API Endpoint' do
       result = JSON.parse(response.body, symbolize_names: true)
       new_plant = UserPlant.last
 
-
       expect(response).to be_successful
       expect(new_plant.plant_id).to eq(plant.id)
       expect(new_plant.user_id).to eq(user.id)
@@ -24,6 +23,21 @@ RSpec.describe 'User Plants API Endpoint' do
       result = JSON.parse(response.body, symbolize_names: true)
 
       expect(response.status).to eq(400)
+    end
+  end
+
+  describe 'DELETE /user_plants' do
+    it 'removes the plant from the users list of plants' do
+      plant = Plant.create!(plant_type: "Tomato", name: "Sungold", days_relative_to_frost_date: 14, days_to_maturity: 54, hybrid_status: 1)
+      user = User.create!(name: "Joel User", email: 'joel@123.com', password: "12345", zip_code: 80123)
+      user_plant = UserPlant.create(user_id: user.id, plant_id: plant.id)
+
+      delete "/api/v1/user_plants/#{user_plant.id}" # Would like to refactor this to use params but it does not like them for some reason.
+      result = JSON.parse(response.body, symbolize_names: true)
+
+      expect(result[:data][:attributes][:id]).to eq(user_plant.id)
+      expect(result[:data][:attributes][:user_id]).to eq(user.id)
+      expect(result[:data][:attributes][:plant_id]).to eq(plant.id)
     end
   end
 end


### PR DESCRIPTION
This PR:

- Exposes a new endpoint at `DELETE /api/v1/user_plants` for users of the application to be able to remove a plant from their planned plants to plant.

- 100% RSpec test coverage.