### PR TITLE
Update plant

### DIFF
--- a/app/controllers/api/v1/plants_controller.rb
+++ b/app/controllers/api/v1/plants_controller.rb
@@ -6,6 +6,11 @@ class Api::V1::PlantsController < ApplicationController
     end
   end
 
+  def update
+    plant = Plant.update(plant_params)
+    render json: PlantSerializer.new(plant), status: 200
+  end
+
   private
   def plant_params
     params.permit(

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
       resources :user_plants, only: [:create, :destroy]
       resources :sessions, only: [:create]
       resources :forecast, only: [:create]
-      resources :plants, only: [:create]
+      resources :plants, only: [:create, :update]
     end
   end
 end

--- a/spec/requests/api/v1/plant_request_spec.rb
+++ b/spec/requests/api/v1/plant_request_spec.rb
@@ -6,7 +6,16 @@ RSpec.describe 'Plant API Endpoints' do
       plant = {plant_type: "Tomato", name: "Sungold", days_relative_to_frost_date: 14, days_to_maturity: 54, hybrid_status: 1}
       post '/api/v1/plants', params: plant
       result = JSON.parse(response.body, symbolize_names: true)
+    end
+  end
 
+  describe 'PATCH /plants' do
+    it 'updates an existing plant with new attributes' do
+      plant = Plant.create(plant_type: "Tomato", name: "Sungold", days_relative_to_frost_date: 14, days_to_maturity: 54, hybrid_status: 1)
+      patch "/api/v1/plants/#{plant.id}", params: { days_to_maturity: 61 }
+      result = JSON.parse(response.body, symbolize_names: true)
+      
+      expect(result[:data][0][:attributes][:days_to_maturity]).to eq(61)
     end
   end
 end


### PR DESCRIPTION
This PR:

- Exposes a new endpoint at `PATCH '/api/v1/plants` in order to update a plants attributes.
- [x]100% RSpec coverage