### PR TITLE
Delete plant

### DIFF
--- a/app/controllers/api/v1/plants_controller.rb
+++ b/app/controllers/api/v1/plants_controller.rb
@@ -11,6 +11,16 @@ class Api::V1::PlantsController < ApplicationController
     render json: PlantSerializer.new(plant), status: 200
   end
 
+  def destroy
+    plant = Plant.find(params[:id])
+    if !plant.nil?
+      deleted_plant = plant.destroy
+      render json: PlantSerializer.new(deleted_plant), status: 200
+    else
+      render json: PlantSerializer.error("Something happened!"), status: 400
+    end
+  end
+
   private
   def plant_params
     params.permit(

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
       resources :user_plants, only: [:create, :destroy]
       resources :sessions, only: [:create]
       resources :forecast, only: [:create]
-      resources :plants, only: [:create, :update]
+      resources :plants, only: [:create, :update, :destroy]
     end
   end
 end

--- a/spec/requests/api/v1/plant_request_spec.rb
+++ b/spec/requests/api/v1/plant_request_spec.rb
@@ -14,8 +14,21 @@ RSpec.describe 'Plant API Endpoints' do
       plant = Plant.create(plant_type: "Tomato", name: "Sungold", days_relative_to_frost_date: 14, days_to_maturity: 54, hybrid_status: 1)
       patch "/api/v1/plants/#{plant.id}", params: { days_to_maturity: 61 }
       result = JSON.parse(response.body, symbolize_names: true)
-      
+
       expect(result[:data][0][:attributes][:days_to_maturity]).to eq(61)
+    end
+  end
+
+  describe 'DELETE /plants' do
+    it 'removes a plant from the list of available plants' do
+      plant1 = Plant.create(plant_type: "Tomato", name: "Sungold", days_relative_to_frost_date: 14, days_to_maturity: 54, hybrid_status: 1)
+      plant2 = Plant.create(plant_type: "Pepper", name: "Jalafuego", days_relative_to_frost_date: 14, days_to_maturity: 65, hybrid_status: 1)
+      plant3 = Plant.create(plant_type: "Radish", name: "French Breakfast", days_relative_to_frost_date: 30, days_to_maturity: 21, hybrid_status: 1)
+
+      delete "/api/v1/plants/#{plant3.id}"
+      result = JSON.parse(response.body, symbolize_names: true)
+
+      expect(Plant.find_by(id: plant3.id)).to be nil
     end
   end
 end


### PR DESCRIPTION
This PR Includes: 

- A new endpoint at `DELETE /api/v1/plants` in order to remove a plant from the database.
-[x] 100% RSpec coverage.