### PR TITLE
Removed erroneous requirement to login with an auth token

### DIFF
--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -1,4 +1,6 @@
 class Api::V1::SessionsController < ApplicationController
+  skip_before_action :authorized, only: [:create]
+  
   def create
     user = User.find_by(email: params[:email])
 

--- a/spec/requests/api/v1/sessions_request_spec.rb
+++ b/spec/requests/api/v1/sessions_request_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'User Sessions' do
       expect(response).to be_successful
 
       login_params = { email: 'joel@plantcoach.com', password: '12345' }
-      post '/api/v1/sessions', params: login_params, headers: { Authorization: "Bearer #{user_response[:jwt]}" }
+      post '/api/v1/sessions', params: login_params #, headers: { Authorization: "Bearer #{user_response[:jwt]}" }
 
       expect(response).to be_successful
     end


### PR DESCRIPTION
The login process previously was set so that a visitor who wants to log in would be required to have an auth-token which doesnt make sense.  The auth token should only be required for an authenticated session so the requirement for authentication for a `session#create` were not realistic and were changed in the `before_action :authentication`.