### PR TITLE
Get user plants endpoint

### DIFF
--- a/app/controllers/api/v1/user_plants_controller.rb
+++ b/app/controllers/api/v1/user_plants_controller.rb
@@ -6,20 +6,20 @@ class Api::V1::UserPlantsController < ApplicationController
 
   def create
     user_plant = UserPlant.create(
-      user_id: params[:user_id],
+      user_id: @user.id,
       plant_id: params[:plant_id]
     )
 
     if user_plant.save
-      user = User.find(params[:user_id])
       plant = Plant.find(params[:plant_id])
-      render json: UserPlantSerializer.format(user, plant)
+      render json: UserPlantSerializer.format(@user, plant)
     else
       render json: UserPlantSerializer.error("There was a problem."), status: 400
     end
   end
 
   def destroy
+    require 'pry'; binding.pry
     user_plant = UserPlant.find(params[:id])
     if user_plant != nil
       result = UserPlant.destroy(user_plant.id)

--- a/app/controllers/api/v1/user_plants_controller.rb
+++ b/app/controllers/api/v1/user_plants_controller.rb
@@ -19,7 +19,6 @@ class Api::V1::UserPlantsController < ApplicationController
   end
 
   def destroy
-    require 'pry'; binding.pry
     user_plant = UserPlant.find(params[:id])
     if user_plant != nil
       result = UserPlant.destroy(user_plant.id)

--- a/app/controllers/api/v1/user_plants_controller.rb
+++ b/app/controllers/api/v1/user_plants_controller.rb
@@ -1,4 +1,9 @@
 class Api::V1::UserPlantsController < ApplicationController
+  def index
+    user_plants = @user.find_users_plants
+    render json: PlantSerializer.new(user_plants), status: 200
+  end
+
   def create
     user_plant = UserPlant.create(
       user_id: params[:user_id],

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,8 @@ class User < ApplicationRecord
 
   has_many :user_plants
   has_many :plants, through: :user_plants
+
+  def find_users_plants
+    plants.where('user_plants.user_id = ?', "#{self.id}")
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :users, only: [:create, :update]
-      resources :user_plants, only: [:create, :destroy]
+      resources :user_plants, only: [:index, :create, :destroy]
       resources :sessions, only: [:create]
       resources :forecast, only: [:create]
       resources :plants, only: [:create, :update, :destroy]

--- a/spec/requests/api/v1/user_plants_request_spec.rb
+++ b/spec/requests/api/v1/user_plants_request_spec.rb
@@ -71,6 +71,70 @@ RSpec.describe 'User Plants API Endpoint' do
     end
   end
 
+  describe 'GET /user_plants' do
+    it 'retrieves an array of the plants that belong to the user' do
+      user_data = {
+        name: 'Joel Grant',
+        email: 'joel@plantcoach.com',
+        zip_code: '80121',
+        password: '12345',
+        password_confirmation: '12345'
+      }
+      post '/api/v1/users', params: user_data
+      user_response = JSON.parse(response.body, symbolize_names: true)
+
+      plant1 = Plant.create!(
+        plant_type: "Tomato",
+        name: "Sungold",
+        days_relative_to_frost_date: 14,
+        days_to_maturity: 54,
+        hybrid_status: 1
+      )
+      plant2 = Plant.create!(
+        plant_type: "Pepper",
+        name: "Jalafuego",
+        days_relative_to_frost_date: 14,
+        days_to_maturity: 65,
+        hybrid_status: 1
+      )
+      unused_plant = Plant.create!(
+        plant_type: "Pepper",
+        name: "Jalafuego",
+        days_relative_to_frost_date: 14,
+        days_to_maturity: 65,
+        hybrid_status: 1
+      )
+      UserPlant.create(
+        user_id: user_response[:user][:data][:id],
+        plant_id: plant1.id
+      )
+      UserPlant.create(
+        user_id: user_response[:user][:data][:id],
+        plant_id: plant2.id
+      )
+
+      get '/api/v1/user_plants', headers: {
+        Authorization: "Bearer #{user_response[:jwt]}"
+      }
+
+      result = JSON.parse(response.body, symbolize_names: true)
+
+      expect(result).to be_a Hash
+      expect(result[:data]).to be_an Array
+
+      #This makes sure the 'unused_plant' variable above is intentionally excluded
+      expect(result[:data].count).to eq(2)
+
+      result[:data].each do |plant|
+        expect(plant[:attributes][:plant_type]).to be_a String
+        expect(plant[:attributes][:name]).to be_a String
+        expect(plant[:attributes][:days_relative_to_frost_date]).to be_an Integer
+        expect(plant[:attributes][:days_to_maturity]).to be_an Integer
+        expect(plant[:attributes][:hybrid_status]).to be_an Integer
+      end
+    end
+  end
+
   describe 'DELETE /user_plants' do
     it 'removes the plant from the users list of plants' do
       body = {

--- a/spec/requests/api/v1/user_plants_request_spec.rb
+++ b/spec/requests/api/v1/user_plants_request_spec.rb
@@ -21,10 +21,7 @@ RSpec.describe 'User Plants API Endpoint' do
         hybrid_status: 1
       )
 
-      post '/api/v1/user_plants', params: {
-        user_id: user_response[:user][:data][:id],
-        plant_id: plant.id
-        }, headers: {
+      post '/api/v1/user_plants', params: { plant_id: plant.id }, headers: {
           Authorization: "Bearer #{user_response[:jwt]}"
         }
       result = JSON.parse(response.body, symbolize_names: true)
@@ -53,16 +50,8 @@ RSpec.describe 'User Plants API Endpoint' do
         days_to_maturity: 54,
         hybrid_status: 1
       )
-      user = User.create!(
-        name: "Joel User",
-        email: 'joel@123.com',
-        password: "12345",
-        zip_code: 80123
-      )
 
-      post '/api/v1/user_plants', params: {
-        user_id: nil, plant_id: plant.id
-        }, headers: {
+      post '/api/v1/user_plants', params: { plant_id: "Useless Data"}, headers: {
           Authorization: "Bearer #{user_response[:jwt]}"
         }
       result = JSON.parse(response.body, symbolize_names: true)
@@ -154,13 +143,10 @@ RSpec.describe 'User Plants API Endpoint' do
         days_to_maturity: 54,
         hybrid_status: 1
       )
-      user = User.create!(
-        name: "Joel User",
-        email: 'joel@123.com',
-        password: "12345",
-        zip_code: 80123
+      user_plant = UserPlant.create(
+        user_id: user_response[:user][:data][:id],
+        plant_id: plant.id
       )
-      user_plant = UserPlant.create(user_id: user.id, plant_id: plant.id)
       # Would like to refactor this to use params hash.
       delete "/api/v1/user_plants/#{user_plant.id}", headers: {
         Authorization: "Bearer #{user_response[:jwt]}"
@@ -168,7 +154,7 @@ RSpec.describe 'User Plants API Endpoint' do
       result = JSON.parse(response.body, symbolize_names: true)
 
       expect(result[:data][:attributes][:id]).to eq(user_plant.id)
-      expect(result[:data][:attributes][:user_id]).to eq(user.id)
+      expect(result[:data][:attributes][:user_id]).to eq(user_response[:user][:data][:id].to_i)
       expect(result[:data][:attributes][:plant_id]).to eq(plant.id)
     end
   end


### PR DESCRIPTION
## Changes to user experience
- NA

## Changes to code: 
- Expose a new endpoint for the FE app to retrieve a user's plants and show them on a dashboard (or anywhere else).
- Created SQL query to retrieve all plants that belong to a user in the database.
- Fixed some tests that would send user data as part of the call.
   - Now works solely with JWT

-[x] 100% RSpec coverage