### PR TITLE
Refactor user plant output

### DIFF
--- a/app/controllers/api/v1/user_plants_controller.rb
+++ b/app/controllers/api/v1/user_plants_controller.rb
@@ -12,7 +12,7 @@ class Api::V1::UserPlantsController < ApplicationController
 
     if user_plant.save
       plant = Plant.find(params[:plant_id])
-      render json: UserPlantSerializer.format(@user, plant)
+      render json: UserPlantSerializer.new(plant)
     else
       render json: UserPlantSerializer.error("There was a problem."), status: 400
     end
@@ -22,7 +22,7 @@ class Api::V1::UserPlantsController < ApplicationController
     user_plant = UserPlant.find(params[:id])
     if user_plant != nil
       result = UserPlant.destroy(user_plant.id)
-      render json: UserPlantSerializer.new(result), status: 200
+      render json: UserPlantSerializer.confirm, status: 200
     end
   end
 end

--- a/app/serializers/user_plant_serializer.rb
+++ b/app/serializers/user_plant_serializer.rb
@@ -1,23 +1,17 @@
 class UserPlantSerializer
   include JSONAPI::Serializer
-  attributes :id, :user_id, :plant_id
+  attributes :id, :name, :plant_type, :days_relative_to_frost_date, :days_to_maturity, :hybrid_status
 
-  def self.format(user, plant)
-    {
-      "data": {
-        "attributes": {
-          "user": user.name,
-          "user_id": user.id,
-          "plant": plant.name,
-          "plant_id": plant.id
-        }
-      }
-    }
-  end
 
   def self.error(message)
     {
       "error": message
+    }
+  end
+
+  def self.confirm
+    {
+      "status": "success"
     }
   end
 end

--- a/spec/requests/api/v1/user_plants_request_spec.rb
+++ b/spec/requests/api/v1/user_plants_request_spec.rb
@@ -28,8 +28,14 @@ RSpec.describe 'User Plants API Endpoint' do
       new_plant = UserPlant.last
 
       expect(response).to be_successful
+      
       expect(new_plant.plant_id).to eq(plant.id)
-      # expect(new_plant.user_id).to eq(user.id)
+
+      expect(result).to be_a Hash
+      expect(result).to have_key(:data)
+
+      expect(result[:data]).to be_a Hash
+      expect(result[:data][:attributes][:name]).to eq(plant.name)
     end
 
     it 'will return a json error message if there was a problem' do

--- a/spec/requests/api/v1/user_plants_request_spec.rb
+++ b/spec/requests/api/v1/user_plants_request_spec.rb
@@ -159,9 +159,7 @@ RSpec.describe 'User Plants API Endpoint' do
       }
       result = JSON.parse(response.body, symbolize_names: true)
 
-      expect(result[:data][:attributes][:id]).to eq(user_plant.id)
-      expect(result[:data][:attributes][:user_id]).to eq(user_response[:user][:data][:id].to_i)
-      expect(result[:data][:attributes][:plant_id]).to eq(plant.id)
+      expect(result[:status]).to eq("success")
     end
   end
 end


### PR DESCRIPTION
## Changes to code:
- The response for accessing the user plant endpoints were returning user data so this has been modified to be a more uniform plant response.
- When deleting a user_plant from the data base there is a simple success message that is returned.

