### PR TITLE
Modify user plant destroy

### DIFF
--- a/app/controllers/api/v1/user_plants_controller.rb
+++ b/app/controllers/api/v1/user_plants_controller.rb
@@ -19,7 +19,7 @@ class Api::V1::UserPlantsController < ApplicationController
   end
 
   def destroy
-    user_plant = UserPlant.find(params[:id])
+    user_plant = @user.find_user_plant_by_plant_id(params[:id])
     if user_plant != nil
       result = UserPlant.destroy(user_plant.id)
       render json: UserPlantSerializer.confirm, status: 200

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,4 +11,8 @@ class User < ApplicationRecord
   def find_users_plants
     plants.where('user_plants.user_id = ?', "#{self.id}")
   end
+
+  def find_user_plant_by_plant_id(id)
+    user_plants.where(plant_id: id).first
+  end
 end

--- a/spec/requests/api/v1/user_plants_request_spec.rb
+++ b/spec/requests/api/v1/user_plants_request_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'User Plants API Endpoint' do
       new_plant = UserPlant.last
 
       expect(response).to be_successful
-      
+
       expect(new_plant.plant_id).to eq(plant.id)
 
       expect(result).to be_a Hash
@@ -154,7 +154,7 @@ RSpec.describe 'User Plants API Endpoint' do
         plant_id: plant.id
       )
       # Would like to refactor this to use params hash.
-      delete "/api/v1/user_plants/#{user_plant.id}", headers: {
+      delete "/api/v1/user_plants/#{plant.id}", headers: {
         Authorization: "Bearer #{user_response[:jwt]}"
       }
       result = JSON.parse(response.body, symbolize_names: true)


### PR DESCRIPTION
## Changes to User Experience: 
- NA

## Changes to Code: 
- Since the plants seen on a dashboard are identified by the plant id, the delete requests also have to be made with the plant ID instead of the user_plant id.
- The user_plant#destroy method was modified to take a plant id as an argument and find the appropriate user_plant before deleting it.
- This is will match the functionality needed for the front end of the application.