### PR TITLE
Delete user

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -31,6 +31,11 @@ class Api::V1::UsersController < ApplicationController
     end
   end
 
+  def destroy
+    @user.destroy
+    render status: 204
+  end
+
   private
   def user_params
     params.permit(:name, :email, :zip_code, :password, :password_confirmation)

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -7,4 +7,10 @@ class UserSerializer
       "error": error_message
     }
   end
+
+  def self.delete(error_message)
+    {
+      "message": error_message
+    }
+  end
 end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -7,10 +7,4 @@ class UserSerializer
       "error": error_message
     }
   end
-
-  def self.delete(error_message)
-    {
-      "message": error_message
-    }
-  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
-      resources :users, only: [:index, :create, :update]
+      resources :users, only: [:index, :create, :update, :destroy]
       resources :user_plants, only: [:index, :create, :destroy]
       resources :sessions, only: [:create]
       resources :forecast, only: [:index]

--- a/spec/requests/api/v1/users_request_spec.rb
+++ b/spec/requests/api/v1/users_request_spec.rb
@@ -156,4 +156,27 @@ RSpec.describe 'Users API' do
       expect(result[:data][:attributes]).to have_key(:zip_code)
     end
   end
+
+  describe 'DELETE /users' do
+    it 'deletes the users account and associations' do
+      body = {
+        name: 'Joel Grant',
+        email: 'joel@requestspectests.com',
+        zip_code: '80121',
+        password: '12345',
+        password_confirmation: '12345'
+      }
+      post '/api/v1/users', params: body
+      user_response = JSON.parse(response.body, symbolize_names: true)
+
+      expect(response).to be_successful
+
+      get '/api/v1/users', headers: { Authorization: "Bearer #{user_response[:jwt]}"}
+      result = JSON.parse(response.body, symbolize_names: true)
+
+      delete "/api/v1/users/#{result[:data][:id]}", headers: { Authorization: "Bearer #{user_response[:jwt]}" }
+
+      expect(response.status).to be 204
+    end
+  end
 end


### PR DESCRIPTION
What changed?
- There is now an endpoint to delete a user account from the application database.
- When deleted, a 204 response is returned.
- `delete /api/v1/users/id`

